### PR TITLE
refactor: primitive type explanation and examples

### DIFF
--- a/basic-syntax.html
+++ b/basic-syntax.html
@@ -61,15 +61,15 @@ let x: i32 = 5;
 
 Rust has a few primitive types:
 
-* Booleans are `true` and `false`
-* Integers, both signed and unsigned: `u8`/`i8`, `u16`/`i16`, `u32`/i32`, `u64`/i64`, and `u128`/`i128`.
-* Floating point numbers, `f32` and `f64`
-* Tuples for grouping different types together: `(i32, f64, i8)`
-* Arrays, that are fixed size: `[u32; 3]` is the type of `[1, 2, 3]`
-* References, like pointers but safer: `&i32` is the type of `&5`
-* Slices, that refer to parts of an array: `&[u8]`
-* `char` is a single Unicode Scalar Value, and uses single quotes: `'🦀'`
-* `&str` is an immutable UTF-8 string: `"this is a crab: 🦀"`
+* **Booleans**: are *true* and *false*
+* **Integers**: are both signed and unsigned. *u8*/*i8*, *u16*/*i16*, *u32*/*i32*, *u64*/*i64*, and *u128*/*i128*.
+* **Floating point numbers**:, *f32* and *f64*
+* **Tuples**: are for grouping different types together *(i32, f64, i8)*
+* **Arrays**: that are fixed size *[u32; 3]* is the type of *[1, 2, 3]*
+* **References**: like pointers but safer. *&i32* is the type of *&5*
+* **Slices**: refer to parts of an array *&[u8]*
+* **char**: is a single Unicode Scalar Value, and uses single quotes *'🦀'*
+* **&str**: is an immutable UTF-8 string *"this is a crab: 🦀"*
 
 ---
 class: middle, left


### PR DESCRIPTION
Couple of changes made...

* Changed the wording to have an uniform style.
* `code` is not getting rendered in bullet points with '`' changed it and examples to italics.
* Made the type names bolder

changed from 
![image](https://user-images.githubusercontent.com/2767425/38349812-584db5de-38c6-11e8-9a24-c5b7e87863e3.png)

to this...

![image](https://user-images.githubusercontent.com/2767425/38349825-6460d9a0-38c6-11e8-8032-b6f41162c307.png)

Let me know if you got any comments :smile: