### PR TITLE
Fixed small error in basic syntax

### DIFF
--- a/basic-syntax.html
+++ b/basic-syntax.html
@@ -256,7 +256,7 @@ impl Point {
 
 let origin = Point { x: 0, y: 0 };
 
-point.print(); // prints "(0, 0)"
+origin.print(); // prints "(0, 0)"
 ```
     </textarea>
     <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript">


### PR DESCRIPTION
changed `point.print()` to `origin.pring()` at  https://github.com/steveklabnik/rust-in-ten-slides/blob/178ca7fccec2907300b1bfb0ba121daba4077d0c/basic-syntax.html#L259 Fixes #11 